### PR TITLE
feat(format): switch markdown formatting to mdformat

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Personal Neovim build focused on speed, zero fluff, and a consistent DX across m
 | `core.plugins.treesitter` | Syntax/indent with `ensure_installed` for common languages. |
 | `core.plugins.lspconfig` | Sets up `lazydev`, `lua_ls`, shared LSP keymaps, diagnostics, and Mason tooling. |
 | `core.plugins.blink-cmp` | Completion engine with LuaSnip + lazydev integration and `super-tab` keymap preset. |
-| `core.plugins.conform` | Formatting with per-filetype config (`stylua` default). |
+| `core.plugins.conform` | Formatting with per-filetype config (`stylua`, `mdformat` for markdown). |
 | `core.plugins.lint` | `nvim-lint` + autocmds for markdown/json linting. |
 
 #### Mini Submodules
@@ -87,7 +87,7 @@ Personal Neovim build focused on speed, zero fluff, and a consistent DX across m
 
 - `lazydev`: enriches Lua language intelligence by preloading Neovim runtime types and keeping `lua_ls` aware of config/plugin files.
 - `nvim-lspconfig`: core LSP client setup with buffer-local keymaps, diagnostic styling, autocommands for highlights/inlay hints, and Mason integration.
-- `mason.nvim` + `mason-lspconfig.nvim` + `mason-tool-installer.nvim`: ensure servers (`lua_ls`, future entries) plus formatters (e.g., `stylua`) are installed automatically.
+- `mason.nvim` + `mason-lspconfig.nvim` + `mason-tool-installer.nvim`: ensure servers (`lua_ls`, future entries) plus formatters (e.g., `stylua`, `mdformat`, `mdformat-frontmatter`) are installed automatically.
 - `j-hui/fidget.nvim`: lightweight status indicator to surface LSP progress without cluttering the UI.
 
 ### User Layer (`lua/user/plugins/`)

--- a/lua/core/plugins/conform.lua
+++ b/lua/core/plugins/conform.lua
@@ -30,6 +30,14 @@ function M.config()
         end,
         formatters_by_ft = {
           lua = { 'stylua' },
+          markdown = { 'mdformat' },
+        },
+        formatters = {
+          mdformat = {
+            -- Load common markdown format plugins when available.
+            -- Example: install `mdformat-frontmatter` to enable frontmatter support.
+            args = { '$FILENAME' },
+          },
         },
       },
     },

--- a/lua/core/plugins/lspconfig.lua
+++ b/lua/core/plugins/lspconfig.lua
@@ -130,7 +130,7 @@ function M.config()
         }
 
         local ensure_installed = vim.tbl_keys(servers or {})
-        vim.list_extend(ensure_installed, { 'stylua' })
+        vim.list_extend(ensure_installed, { 'stylua', 'mdformat', 'mdformat-frontmatter' })
         require('mason-tool-installer').setup { ensure_installed = ensure_installed }
 
         require('mason-lspconfig').setup {


### PR DESCRIPTION
### Motivation
- Prefer a dedicated Markdown formatter instead of relying on LSP fallback (Marksman or similar) to provide consistent formatting for markdown files. 
- Allow users to opt-in to mdformat plugins (for example `mdformat-frontmatter`) so frontmatter and other markdown extensions are supported when installed.

### Description
- Configure `conform.nvim` to use `mdformat` for `markdown` by adding `markdown = { 'mdformat' }` to `formatters_by_ft` in `lua/core/plugins/conform.lua`.
- Add an explicit `mdformat` formatter config entry in `lua/core/plugins/conform.lua` with `args = { '$FILENAME' }` and a note about loading mdformat plugins such as `mdformat-frontmatter`.
- Add `mdformat` and `mdformat-frontmatter` to the Mason tool installer `ensure_installed` list in `lua/core/plugins/lspconfig.lua` so the tooling can be bootstrapped automatically.
- Update `README.md` to reflect that `mdformat` is used for markdown formatting and to mention the expanded Mason formatter list.

### Testing
- Ran `nvim --headless -u NONE "+luafile lua/core/plugins/conform.lua" "+luafile lua/core/plugins/lspconfig.lua" +qa` which loaded both modified files without errors.
- Attempted `luac -p` style syntax checks but `luac` is not available in this environment, so that specific check failed due to the missing tool rather than a Lua syntax error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fd921f43c832badba7ba4c53a423b)